### PR TITLE
Add CSS properties to make headings responsive to screen sizes

### DIFF
--- a/refactored-project/styles.css
+++ b/refactored-project/styles.css
@@ -8,6 +8,8 @@ body {
   background-repeat: no-repeat;
   background-size: cover;
   background-position: fixed;
+  font-size: 100%;
+  margin: 0px;
 }
 
 main {
@@ -20,13 +22,14 @@ header {
 
 h1 {
   font-family: 'Skranji', cursive;
-  font-size: 7.5em;
+  font-size: min(10vw, 95px);
+  padding: 2rem 0;
   margin-bottom: 0;
   margin-top: 0;
 }
 
 h2 {
-  font-size: 2rem;
+  font-size: min(7vw, 2rem);
   text-align: center;
   height: 100%;
   width: 80%;
@@ -55,7 +58,7 @@ button:active {
 
 h4 {
   text-align: center;
-  font-size: 3em;
+  font-size: min(4vw, 3em);
   color: black;
   margin-top: 2.5%;
   margin-bottom: 2.5%;
@@ -103,11 +106,11 @@ h4 {
 }
 
 .all-color-boxes {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: center;
-  flex-wrap: wrap;
-  width: 80vw;
+  padding: 0.5rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-template-rows: repeat(1, 1fr);
+  gap: 1rem;
 }
 
 .individual-box {
@@ -126,12 +129,14 @@ h4 {
 
 .button-section {
   width: 80vw;
+  margin: 2em;
   display: flex;
   justify-content: space-evenly;
 }
 
 .color-and-lock {
   display: flex;
+  box-sizing: content-box;
   justify-content: flex-end;
   align-items: center;
   width: 100%;
@@ -140,7 +145,7 @@ h4 {
 .lock-button {
   width: 20%;
   height: auto;
-  margin: 1%;
+  margin-left: .25rem;
 }
 
 .lock-button:hover {
@@ -168,3 +173,11 @@ h4 {
   width: 2.5vw;
   border: 2px solid #000000;
 }
+
+@media (max-width: 880px) {
+  .all-color-boxes {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+}
+


### PR DESCRIPTION
# Description
Fixes CSS color box issue that was rendering inconsistent box sizes. 
Adds additional styling to make headings responsive to screen sizes with breakpoint at 880px
Adds a grid to display color boxes within color palettes

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactor

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] I tested my changes in the browser
- [ ] I tested with Mocha/Chai

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new bugs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Is your code D.R.Y?
- [x] Does it follow SRP?